### PR TITLE
Fix Travis CI badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![travis][travis-img]][travis-url] [![appveyor][appveyor-img]][appveyor-url] [![codecov][codecov-img]][codecov-url]
 
-[travis-img]: https://travis-ci.com/thabbott/JULES.jl.svg?branch=master
-[travis-url]: https://travis-ci.com/thabbott/JULES.jl
+[travis-img]: https://travis-ci.org/thabbott/JULES.jl.svg?branch=master
+[travis-url]: https://travis-ci.org/thabbott/JULES.jl
 
 [appveyor-img]: https://ci.appveyor.com/api/projects/status/ni5ifxwqjkbcofsk/branch/master?svg=true
 [appveyor-url]: https://ci.appveyor.com/project/thabbott/jules-jl


### PR DESCRIPTION
Hmmm, I thought `travis-ci.com` and `travis-ci.org` were merged a while back but apparently not because only `.org` works for the JULES.jl Travis link.