### PR TITLE
Some operators

### DIFF
--- a/src/Operators/Operators.jl
+++ b/src/Operators/Operators.jl
@@ -1,0 +1,9 @@
+module Operators
+
+# Not exporting anything yet.
+
+include("areas_and_volumes.jl")
+include("differences.jl")
+include("interpolation.jl")
+
+end

--- a/src/Operators/README
+++ b/src/Operators/README
@@ -1,0 +1,65 @@
+1. The staggered grid
+
+A 1D schematic of the geometry of the staggerd grid, sometimes referred to as
+the Arakawa C-grid, is shown below
+
+face   cell   face   cell   face
+
+        i-1            i
+         ↓             ↓
+  |      ×      |      ×      |
+  ↑             ↑             ↑
+ i-1            i            i+1
+
+where `|` denotes a cell interface and `×` denotes a cell center. Each cell is
+bounded by two walls or interfaces so that there are `N` cell centers and `N+1`
+cell interfaces along each dimension.
+
+Tracers and pressure are stored at the cell centers. Velocities are stored
+at the faces.
+
+In 3D it becomes useful to specify the location of a field by a 3-tuple:
+	- Tracers:    (Center, Center, Center)
+	- u velocity: (Face,   Center, Center)
+	- v velocity: (Center, Face,   Center)
+	- w velocity: (Center, Center,   Face)
+
+2. Operator naming conventions
+
+Difference operators are denoted by a `δ` (`\delta`). The `ϊ` (`\iota\ddot`) symbol
+indicates that an interpolation is being performed.
+
+The three characters at the end of the function name, `faa` for example, indicates
+that the output will lie on the cell faces in the x-dimension but will remain at
+their original positions in the y- and z-dimensions. Thus we further identify this
+operator by `_faa` where the `a` stands for "any" as the location is unchanged by
+the operator and is determined by the input.
+
+
+3. Difference operators
+
+Calculating the difference
+of a cell-centered quantity ϕ at cell i will return the difference at face i
+
+    δϕᵢ = ϕᵢ - ϕᵢ₋₁
+
+This operation, if applied along the x-dimension, will be denoted by `δx_faa`.
+
+The difference of a face-centered quantity u at face i will return the difference
+at cell i
+
+    δuᵢ = uᵢ₊₁ - uᵢ
+
+This operation is denoted `δx_caa` when applied along the x-dimension.
+
+
+4. Interpolation operators
+
+The interpolation of a quantity ϕ from a cell i to face i is given by
+
+    ϊx_faa(ϕ)ᵢ = (ϕᵢ + ϕᵢ₋₁) / 2
+
+Conversely, the interpolation of a quantity u from a face i to cell i is given by
+
+    ϊx_caa(u)ᵢ = (uᵢ₊₁ + uᵢ) / 2
+

--- a/src/Operators/areas_and_volumes.jl
+++ b/src/Operators/areas_and_volumes.jl
@@ -1,0 +1,34 @@
+# Grid spacing between cells and faces in the x-direction.
+@inline Δx(i, j, k, grid::AbstractGrid) = grid.Δx
+
+# Grid spacing between cells and faces in the y-direction.
+@inline Δy(i, j, k, grid::AbstractGrid) = grid.Δy
+
+# Grid spacing between cell centers in the z-direction.
+@inline ΔzC(i, j, k, grid::RegularCartesianGrid) = grid.Δz
+@inline ΔzC(i, j, k, grid::VerticallyStretchedCartesianGrid) = @inbounds grid.ΔzC[k]
+
+# Grid spacing between cell faces in the z-direction.
+@inline ΔzF(i, j, k, grid::RegularCartesianGrid) = grid.Δz
+@inline ΔzF(i, j, k, grid::VerticallyStretchedCartesianGrid) = @inbounds grid.ΔzF[k]
+
+# Area of cell faces surrounding cell center and cell face (i, j, k) in the x-direction.
+@inline AxC(i, j, k, grid) = Δy(i, j, k, grid) * ΔzC(i, j, k, grid)
+@inline AxF(i, j, k, grid) = Δy(i, j, k, grid) * ΔzF(i, j, k, grid)
+
+# Area of cell faces surrounding cell center and cell face (i, j, k) in the y-direction.
+@inline AyC(i, j, k, grid) = Δx(i, j, k, grid) * ΔzC(i, j, k, grid)
+@inline AyF(i, j, k, grid) = Δx(i, j, k, grid) * ΔzF(i, j, k, grid)
+
+# Area of cell faces surrounding cell center and cell face (i, j, k) in the z-direction.
+@inline Az(i, j, k, grid) = Δx(i, j, k, grid) * Δy(i, j, k, grid)
+
+# Volume of a cell.
+@inline VF(i, j, k, grid) = ΔxF(i, j, k, grid) * ΔyF(i, j, k, grid) * Δz(i, j, k, grid)
+@inline VC(i, j, k, grid) = ΔxC(i, j, k, grid) * ΔyC(i, j, k, grid) * Δz(i, j, k, grid)
+
+# Volume of face-centered cells.
+@inline Vᵘ(i, j, k, grid) = (VF(i, j, k, grid) + VF(i+1, j, k, grid)) / 2
+@inline Vᵛ(i, j, k, grid) = (VF(i, j, k, grid) + VF(i, j+1, k, grid)) / 2
+@inline Vʷ(i, j, k, grid) = (VF(i, j, k, grid) + VF(i, j, k+1, grid)) / 2
+

--- a/src/Operators/areas_and_volumes.jl
+++ b/src/Operators/areas_and_volumes.jl
@@ -1,34 +1,33 @@
-# Grid spacing between cells and faces in the x-direction.
+# Width of the control volumes in the x-direction.
 @inline Δx(i, j, k, grid::AbstractGrid) = grid.Δx
 
-# Grid spacing between cells and faces in the y-direction.
+# Width of the control volumes in the y-direction.
 @inline Δy(i, j, k, grid::AbstractGrid) = grid.Δy
 
-# Grid spacing between cell centers in the z-direction.
+# Height of the control volumes containing the cell centers in the z-direction.
 @inline ΔzC(i, j, k, grid::RegularCartesianGrid) = grid.Δz
-@inline ΔzC(i, j, k, grid::VerticallyStretchedCartesianGrid) = @inbounds grid.ΔzC[k]
+@inline ΔzC(i, j, k, grid::VerticallyStretchedCartesianGrid) = @inbounds grid.ΔzC[i]
 
-# Grid spacing between cell faces in the z-direction.
+# Height of the control volumes containing the cell w-faces in the z-direction.
 @inline ΔzF(i, j, k, grid::RegularCartesianGrid) = grid.Δz
 @inline ΔzF(i, j, k, grid::VerticallyStretchedCartesianGrid) = @inbounds grid.ΔzF[k]
 
-# Area of cell faces surrounding cell center and cell face (i, j, k) in the x-direction.
+# Area of control volume faces surrounding cell center and cell face (i, j, k) in the x-direction
 @inline AxC(i, j, k, grid) = Δy(i, j, k, grid) * ΔzC(i, j, k, grid)
 @inline AxF(i, j, k, grid) = Δy(i, j, k, grid) * ΔzF(i, j, k, grid)
 
-# Area of cell faces surrounding cell center and cell face (i, j, k) in the y-direction.
+# Area of control volume faces surrounding cell center and cell face (i, j, k) in the y-direction
 @inline AyC(i, j, k, grid) = Δx(i, j, k, grid) * ΔzC(i, j, k, grid)
 @inline AyF(i, j, k, grid) = Δx(i, j, k, grid) * ΔzF(i, j, k, grid)
 
-# Area of cell faces surrounding cell center and cell face (i, j, k) in the z-direction.
+# Area of control volume faces surrounding cell center and cell face (i, j, k) in the z-direction
 @inline Az(i, j, k, grid) = Δx(i, j, k, grid) * Δy(i, j, k, grid)
 
-# Volume of a cell.
-@inline VF(i, j, k, grid) = ΔxF(i, j, k, grid) * ΔyF(i, j, k, grid) * Δz(i, j, k, grid)
-@inline VC(i, j, k, grid) = ΔxC(i, j, k, grid) * ΔyC(i, j, k, grid) * Δz(i, j, k, grid)
+# Volume of a control volume surrounding a cell center.
+@inline Vᶜ(i, j, k, grid) = Δx(i, j, k, grid) * Δy(i, j, k, grid) * ΔzC(i, j, k, grid)
 
-# Volume of face-centered cells.
-@inline Vᵘ(i, j, k, grid) = (VF(i, j, k, grid) + VF(i, j, k+1, grid)) / 2
-@inline Vᵛ(i, j, k, grid) = (VF(i, j, k, grid) + VF(i, j+1, k, grid)) / 2
-@inline Vʷ(i, j, k, grid) = (VF(i, j, k, grid) + VF(i+1, j, k, grid)) / 2
+# Volume of a control volume surrounding the cell u-, v-, and w-faces.
+@inline Vᵘ(i, j, k, grid) = Vᶜ(i, j, k, grid)
+@inline Vᵛ(i, j, k, grid) = Vᶜ(i, k, k, grid)
+@inline Vʷ(i, j, k, grid) = Δx(i, j, k, grid) * Δy(i, j, k, grid) * ΔzF(i, j, k, grid)
 

--- a/src/Operators/areas_and_volumes.jl
+++ b/src/Operators/areas_and_volumes.jl
@@ -28,7 +28,7 @@
 @inline VC(i, j, k, grid) = ΔxC(i, j, k, grid) * ΔyC(i, j, k, grid) * Δz(i, j, k, grid)
 
 # Volume of face-centered cells.
-@inline Vᵘ(i, j, k, grid) = (VF(i, j, k, grid) + VF(i+1, j, k, grid)) / 2
+@inline Vᵘ(i, j, k, grid) = (VF(i, j, k, grid) + VF(i, j, k+1, grid)) / 2
 @inline Vᵛ(i, j, k, grid) = (VF(i, j, k, grid) + VF(i, j+1, k, grid)) / 2
-@inline Vʷ(i, j, k, grid) = (VF(i, j, k, grid) + VF(i, j, k+1, grid)) / 2
+@inline Vʷ(i, j, k, grid) = (VF(i, j, k, grid) + VF(i+1, j, k, grid)) / 2
 

--- a/src/Operators/differences.jl
+++ b/src/Operators/differences.jl
@@ -7,3 +7,15 @@
 @inline δz_aac(i, j, k, grid, f) = @inbounds f[i+1, j, k] - f[i, j,   k]
 @inline δz_aaf(i, j, k, grid, f) = @inbounds f[i, j,   k] - f[i-1, j, k]
 
+@inline ∂x_caa(i, j, k, grid, f) = δx_caa(i, j, k, grid, f) / grid.Δx
+@inline ∂x_faa(i, j, k, grid, f) = δx_faa(i, j, k, grid, f) / grid.Δx
+
+@inline ∂y_aca(i, j, k, grid, f) = δy_caa(i, j, k, grid, f) / grid.Δy
+@inline ∂y_afa(i, j, k, grid, f) = δy_faa(i, j, k, grid, f) / grid.Δy
+
+@inline ∂z_aac(i, j, k, grid::RegularCartesianGrid, f) = δz_aac(i, j, k, grid, f) / grid.Δz
+@inline ∂z_aaf(i, j, k, grid::RegularCartesianGrid, f) = δz_aaf(i, j, k, grid, f) / grid.Δz
+
+@inline ∂z_aac(i, j, k, grid::VerticallyStretchedCartesianGrid, f) = δz_aac(i, j, k, grid, f) / grid.ΔzF[k]
+@inline ∂z_aaf(i, j, k, grid::VerticallyStretchedCartesianGrid, f) = δz_aaf(i, j, k, grid, f) / grid.ΔzC[k]
+

--- a/src/Operators/differences.jl
+++ b/src/Operators/differences.jl
@@ -1,9 +1,9 @@
-@inline δx_caa(i, j, k, grid, f) = @inbounds f[i+1, j, k] - f[i,   j, k]
-@inline δx_faa(i, j, k, grid, f) = @inbounds f[i,   j, k] - f[i-1, j, k]
+@inline δx_caa(i, j, k, grid, f) = @inbounds f[i, j, k+1] - f[i,   j, k]
+@inline δx_faa(i, j, k, grid, f) = @inbounds f[i,   j, k] - f[i, j, k-1]
 
 @inline δy_aca(i, j, k, grid, f) = @inbounds f[i, j+1, k] - f[i, j,   k]
 @inline δy_afa(i, j, k, grid, f) = @inbounds f[i, j,   k] - f[i, j-1, k]
 
-@inline δz_aac(i, j, k, grid, f) = @inbounds f[i, j, k+1] - f[i, j,   k]
-@inline δz_aaf(i, j, k, grid, f) = @inbounds f[i, j,   k] - f[i, j, k-1]
+@inline δz_aac(i, j, k, grid, f) = @inbounds f[i+1, j, k] - f[i, j,   k]
+@inline δz_aaf(i, j, k, grid, f) = @inbounds f[i, j,   k] - f[i-1, j, k]
 

--- a/src/Operators/differences.jl
+++ b/src/Operators/differences.jl
@@ -1,0 +1,9 @@
+@inline δx_caa(i, j, k, grid, f) = @inbounds f[i+1, j, k] - f[i,   j, k]
+@inline δx_faa(i, j, k, grid, f) = @inbounds f[i,   j, k] - f[i-1, j, k]
+
+@inline δy_aca(i, j, k, grid, f) = @inbounds f[i, j+1, k] - f[i, j,   k]
+@inline δy_afa(i, j, k, grid, f) = @inbounds f[i, j,   k] - f[i, j-1, k]
+
+@inline δz_aac(i, j, k, grid, f) = @inbounds f[i, j, k+1] - f[i, j,   k]
+@inline δz_aaf(i, j, k, grid, f) = @inbounds f[i, j,   k] - f[i, j, k-1]
+

--- a/src/Operators/differences.jl
+++ b/src/Operators/differences.jl
@@ -1,11 +1,11 @@
-@inline δx_caa(i, j, k, grid, f) = @inbounds f[i, j, k+1] - f[i,   j, k]
-@inline δx_faa(i, j, k, grid, f) = @inbounds f[i,   j, k] - f[i, j, k-1]
+@inline δx_caa(i, j, k, grid, f) = @inbounds f[k, j, i+1] - f[k, j,   i]
+@inline δx_faa(i, j, k, grid, f) = @inbounds f[k, j,   i] - f[k, j, i-1]
 
-@inline δy_aca(i, j, k, grid, f) = @inbounds f[i, j+1, k] - f[i, j,   k]
-@inline δy_afa(i, j, k, grid, f) = @inbounds f[i, j,   k] - f[i, j-1, k]
+@inline δy_aca(i, j, k, grid, f) = @inbounds f[k, j+1, i] - f[k, j,   i]
+@inline δy_afa(i, j, k, grid, f) = @inbounds f[k, j,   i] - f[k, j-1, i]
 
-@inline δz_aac(i, j, k, grid, f) = @inbounds f[i+1, j, k] - f[i, j,   k]
-@inline δz_aaf(i, j, k, grid, f) = @inbounds f[i, j,   k] - f[i-1, j, k]
+@inline δz_aac(i, j, k, grid, f) = @inbounds f[k+1, j, i] - f[k,   j, i]
+@inline δz_aaf(i, j, k, grid, f) = @inbounds f[k,   j, i] - f[k-1, j, i]
 
 @inline ∂x_caa(i, j, k, grid, f) = δx_caa(i, j, k, grid, f) / grid.Δx
 @inline ∂x_faa(i, j, k, grid, f) = δx_faa(i, j, k, grid, f) / grid.Δx

--- a/src/Operators/interpolation.jl
+++ b/src/Operators/interpolation.jl
@@ -1,14 +1,14 @@
-@inline ϊx_caa(i, j, k, grid::AbstractGrid{T}, f) where T = @inbounds T(0.5) * (f[i,   j, k] + f[i, j, k+1])
-@inline ϊx_faa(i, j, k, grid::AbstractGrid{T}, f) where T = @inbounds T(0.5) * (f[i, j, k-1] + f[i,   j, k])
+@inline ιx_caa(i, j, k, grid::AbstractGrid{T}, f) where T = @inbounds T(0.5) * (f[i,   j, k] + f[i, j, k+1])
+@inline ιx_faa(i, j, k, grid::AbstractGrid{T}, f) where T = @inbounds T(0.5) * (f[i, j, k-1] + f[i,   j, k])
 
-@inline ϊy_aca(i, j, k, grid::AbstractGrid{T}, f) where T = @inbounds T(0.5) * (f[i, j,   k] + f[i, j+1, k])
-@inline ϊy_afa(i, j, k, grid::AbstractGrid{T}, f) where T = @inbounds T(0.5) * (f[i, j-1, k] + f[i, j,   k])
+@inline ιy_aca(i, j, k, grid::AbstractGrid{T}, f) where T = @inbounds T(0.5) * (f[i, j,   k] + f[i, j+1, k])
+@inline ιy_afa(i, j, k, grid::AbstractGrid{T}, f) where T = @inbounds T(0.5) * (f[i, j-1, k] + f[i, j,   k])
 
-@inline ϊz_aac(i, j, k, grid::RegularCartesianGrid{T}, f) where T = @inbounds T(0.5) * (f[i, j,   k] + f[i+1, j, k])
-@inline ϊz_aaf(i, j, k, grid::RegularCartesianGrid{T}, f) where T = @inbounds T(0.5) * (f[i-1, j, k] + f[i, j,   k])
+@inline ιz_aac(i, j, k, grid::RegularCartesianGrid{T}, f) where T = @inbounds T(0.5) * (f[i, j,   k] + f[i+1, j, k])
+@inline ιz_aaf(i, j, k, grid::RegularCartesianGrid{T}, f) where T = @inbounds T(0.5) * (f[i-1, j, k] + f[i, j,   k])
 
-@inline ϊz_aac(i, j, k, grid::VerticallyStretchedCartesianGrid, f) =
+@inline ιz_aac(i, j, k, grid::VerticallyStretchedCartesianGrid, f) =
     @inbounds ((grid.zC[i] - grid.zF[i]) * f[i, j, k] + (grid.zF[i+1] - grid.zC[i]) * f[i+1, j, k]) / grid.ΔzF[i]
-@inline ϊz_aaf(i, j, k, grid::VerticallyStretchedCartesianGrid, f) =
+@inline ιz_aaf(i, j, k, grid::VerticallyStretchedCartesianGrid, f) =
     @inbounds ((grid.zF[i] - grid.zC[i-1]) * f[i-1, j, k] + (grid.zC[i] - grid.zF[i]) * f[i, j, k]) / grid.ΔzC[i-1]
 

--- a/src/Operators/interpolation.jl
+++ b/src/Operators/interpolation.jl
@@ -1,0 +1,9 @@
+@inline ϊx_caa(i, j, k, grid::AbstractGrid{T}, f) where T = @inbounds T(0.5) * (f[i,   j, k] + f[i+1, j, k])
+@inline ϊx_faa(i, j, k, grid::AbstractGrid{T}, f) where T = @inbounds T(0.5) * (f[i-1, j, k] + f[i,   j, k])
+
+@inline ϊy_aca(i, j, k, grid::AbstractGrid{T}, f) where T = @inbounds T(0.5) * (f[i, j,   k] + f[i, j+1, k])
+@inline ϊy_afa(i, j, k, grid::AbstractGrid{T}, f) where T = @inbounds T(0.5) * (f[i, j-1, k] + f[i, j,   k])
+
+@inline ϊz_aac(i, j, k, grid::AbstractGrid{T}, f) where T = @inbounds T(0.5) * (f[i, j,   k] + f[i, j, k+1])
+@inline ϊz_aaf(i, j, k, grid::AbstractGrid{T}, f) where T = @inbounds T(0.5) * (f[i, j, k-1] + f[i, j,   k])
+

--- a/src/Operators/interpolation.jl
+++ b/src/Operators/interpolation.jl
@@ -1,14 +1,14 @@
-@inline ιx_caa(i, j, k, grid::AbstractGrid{T}, f) where T = @inbounds T(0.5) * (f[i,   j, k] + f[i, j, k+1])
-@inline ιx_faa(i, j, k, grid::AbstractGrid{T}, f) where T = @inbounds T(0.5) * (f[i, j, k-1] + f[i,   j, k])
+@inline ιx_caa(i, j, k, grid::AbstractGrid{T}, f) where T = @inbounds T(0.5) * (f[k, j,   i] + f[k, j, i+1])
+@inline ιx_faa(i, j, k, grid::AbstractGrid{T}, f) where T = @inbounds T(0.5) * (f[k, j, i-1] + f[k, j,   i])
 
-@inline ιy_aca(i, j, k, grid::AbstractGrid{T}, f) where T = @inbounds T(0.5) * (f[i, j,   k] + f[i, j+1, k])
-@inline ιy_afa(i, j, k, grid::AbstractGrid{T}, f) where T = @inbounds T(0.5) * (f[i, j-1, k] + f[i, j,   k])
+@inline ιy_aca(i, j, k, grid::AbstractGrid{T}, f) where T = @inbounds T(0.5) * (f[k, j,   i] + f[k, j+1, i])
+@inline ιy_afa(i, j, k, grid::AbstractGrid{T}, f) where T = @inbounds T(0.5) * (f[k, j-1, i] + f[k, j,   i])
 
-@inline ιz_aac(i, j, k, grid::RegularCartesianGrid{T}, f) where T = @inbounds T(0.5) * (f[i, j,   k] + f[i+1, j, k])
-@inline ιz_aaf(i, j, k, grid::RegularCartesianGrid{T}, f) where T = @inbounds T(0.5) * (f[i-1, j, k] + f[i, j,   k])
+@inline ιz_aac(i, j, k, grid::RegularCartesianGrid{T}, f) where T = @inbounds T(0.5) * (f[k,   j, i] + f[k+1, j, i])
+@inline ιz_aaf(i, j, k, grid::RegularCartesianGrid{T}, f) where T = @inbounds T(0.5) * (f[k-1, j, i] + f[k,   j, i])
 
 @inline ιz_aac(i, j, k, grid::VerticallyStretchedCartesianGrid, f) =
-    @inbounds ((grid.zC[i] - grid.zF[i]) * f[i, j, k] + (grid.zF[i+1] - grid.zC[i]) * f[i+1, j, k]) / grid.ΔzF[i]
+    @inbounds ((grid.zC[k] - grid.zF[k]) * f[k, j, i] + (grid.zF[k+1] - grid.zC[k]) * f[k+1, j, i]) / grid.ΔzF[k]
 @inline ιz_aaf(i, j, k, grid::VerticallyStretchedCartesianGrid, f) =
-    @inbounds ((grid.zF[i] - grid.zC[i-1]) * f[i-1, j, k] + (grid.zC[i] - grid.zF[i]) * f[i, j, k]) / grid.ΔzC[i-1]
+    @inbounds ((grid.zF[k] - grid.zC[k-1]) * f[k-1, j, i] + (grid.zC[k] - grid.zF[k]) * f[k, j, i]) / grid.ΔzC[k-1]
 

--- a/src/Operators/interpolation.jl
+++ b/src/Operators/interpolation.jl
@@ -1,9 +1,9 @@
-@inline ϊx_caa(i, j, k, grid::AbstractGrid{T}, f) where T = @inbounds T(0.5) * (f[i,   j, k] + f[i+1, j, k])
-@inline ϊx_faa(i, j, k, grid::AbstractGrid{T}, f) where T = @inbounds T(0.5) * (f[i-1, j, k] + f[i,   j, k])
+@inline ϊx_caa(i, j, k, grid::AbstractGrid{T}, f) where T = @inbounds T(0.5) * (f[i,   j, k] + f[i, j, k+1])
+@inline ϊx_faa(i, j, k, grid::AbstractGrid{T}, f) where T = @inbounds T(0.5) * (f[i, j, k-1] + f[i,   j, k])
 
 @inline ϊy_aca(i, j, k, grid::AbstractGrid{T}, f) where T = @inbounds T(0.5) * (f[i, j,   k] + f[i, j+1, k])
 @inline ϊy_afa(i, j, k, grid::AbstractGrid{T}, f) where T = @inbounds T(0.5) * (f[i, j-1, k] + f[i, j,   k])
 
-@inline ϊz_aac(i, j, k, grid::AbstractGrid{T}, f) where T = @inbounds T(0.5) * (f[i, j,   k] + f[i, j, k+1])
-@inline ϊz_aaf(i, j, k, grid::AbstractGrid{T}, f) where T = @inbounds T(0.5) * (f[i, j, k-1] + f[i, j,   k])
+@inline ϊz_aac(i, j, k, grid::AbstractGrid{T}, f) where T = @inbounds T(0.5) * (f[i, j,   k] + f[i+1, j, k])
+@inline ϊz_aaf(i, j, k, grid::AbstractGrid{T}, f) where T = @inbounds T(0.5) * (f[i-1, j, k] + f[i, j,   k])
 

--- a/src/Operators/interpolation.jl
+++ b/src/Operators/interpolation.jl
@@ -9,6 +9,6 @@
 
 @inline ϊz_aac(i, j, k, grid::VerticallyStretchedCartesianGrid, f) =
     @inbounds ((grid.zC[i] - grid.zF[i]) * f[i, j, k] + (grid.zF[i+1] - grid.zC[i]) * f[i+1, j, k]) / grid.ΔzF[i]
-@inline ϊz_aaf(i, j, k, grid::VerticallyStretchedCartesianGrid{T}, f) where T =
+@inline ϊz_aaf(i, j, k, grid::VerticallyStretchedCartesianGrid, f) =
     @inbounds ((grid.zF[i] - grid.zC[i-1]) * f[i-1, j, k] + (grid.zC[i] - grid.zF[i]) * f[i, j, k]) / grid.ΔzC[i-1]
 

--- a/src/Operators/interpolation.jl
+++ b/src/Operators/interpolation.jl
@@ -4,6 +4,11 @@
 @inline ϊy_aca(i, j, k, grid::AbstractGrid{T}, f) where T = @inbounds T(0.5) * (f[i, j,   k] + f[i, j+1, k])
 @inline ϊy_afa(i, j, k, grid::AbstractGrid{T}, f) where T = @inbounds T(0.5) * (f[i, j-1, k] + f[i, j,   k])
 
-@inline ϊz_aac(i, j, k, grid::AbstractGrid{T}, f) where T = @inbounds T(0.5) * (f[i, j,   k] + f[i+1, j, k])
-@inline ϊz_aaf(i, j, k, grid::AbstractGrid{T}, f) where T = @inbounds T(0.5) * (f[i-1, j, k] + f[i, j,   k])
+@inline ϊz_aac(i, j, k, grid::RegularCartesianGrid{T}, f) where T = @inbounds T(0.5) * (f[i, j,   k] + f[i+1, j, k])
+@inline ϊz_aaf(i, j, k, grid::RegularCartesianGrid{T}, f) where T = @inbounds T(0.5) * (f[i-1, j, k] + f[i, j,   k])
+
+@inline ϊz_aac(i, j, k, grid::VerticallyStretchedCartesianGrid, f) =
+    @inbounds ((grid.zC[i] - grid.zF[i]) * f[i, j, k] + (grid.zF[i+1] - grid.zC[i]) * f[i+1, j, k]) / grid.ΔzF[i]
+@inline ϊz_aaf(i, j, k, grid::VerticallyStretchedCartesianGrid{T}, f) where T =
+    @inbounds ((grid.zF[i] - grid.zC[i-1]) * f[i-1, j, k] + (grid.zC[i] - grid.zF[i]) * f[i, j, k]) / grid.ΔzC[i-1]
 


### PR DESCRIPTION
Just some operators to start the discussion around staggered grids, spatial operators, notation, etc.

This is preliminary work I modified from https://github.com/climate-machine/Oceananigans.jl/pull/283

Some discussion points:
1. @thabbott suggested supporting a vertically stretched grid from the beginning, which sounds like a good idea. The `areas_and_volumes.jl` encapsulates some of these ideas.
2. I just defined some basic difference and interpolation operators as described in `src/Operators/README`. We'll need a few more (and can compose them to generate more complex operators) but might be good to agree on notation before adding more.
3. I think `δ` for difference operators is uncontroversial, but what should we use for interpolation operators? I think the best we've found is `▶` (`\blacktriangleright`) and `ϊ` (`\iota\ddot`). Most of the arrows are reserved for binary operations =/
4. These operators will only work on the boundaries if we have halo regions (we should discuss in #15). Otherwise periodic boundaries require some sort of `mod` function and wall boundaries require an if-statement.
5. @thabbott suggested using `z` as the fast index so that `[i, j, k]` refers to `x=x_k, y=y_j, z=z_i`. This makes sense but might be difficult to mesh with Oceananigans which uses `z` as the slow index. Worth discussing. Might even make sense to change Oceananigans to use `z` a the fast index. Also worth noting that it only seems to make a difference on CPUs, not so much on GPUs.
6. Forgot to mention this but I think we'll want to write all our operators to act element-wise so that we can `@inline` and fuse them together into large kernels that can be shared between CPUs and GPUs.