### PR TITLE
Fields abstractions

### DIFF
--- a/src/fields.jl
+++ b/src/fields.jl
@@ -1,0 +1,52 @@
+"""
+    Cell
+
+A type describing the location at the center of a grid cell.
+"""
+struct Cell end
+
+"""
+	Face
+
+A type describing the location at the face of a grid cell.
+"""
+struct Face end
+
+"""
+    Field{LX, LY, LZ, A, G} <: AbstractField{A, G}
+
+A field defined at the location (`LX`, `LY`, `LZ`) which can be either `Cell` or `Face`.
+"""
+struct Field{Lx, Ly, Lz, A, G} <: AbstractField{A, G}
+    data :: A
+    grid :: G
+end
+
+"""
+	CellField
+
+A field defined at the cell centers. Used for pressure and tracers.
+"""
+const CellField  = Field{Cell, Cell, Cell}
+
+"""
+	FaceFieldX
+
+A field defined at the faces along the x-direction. Used for horizontal velocity u.
+"""
+const FaceFieldX = Field{Face, Cell, Cell}
+
+"""
+	FaceFieldY
+
+A field defined at the faces along the y-direction. Used for horizontal velocity v.
+"""
+const FaceFieldY = Field{Cell, Face, Cell}
+
+"""
+	FaceFieldZ
+
+A field defined at the faces along the z-direction. Used for vertical velocity w.
+"""
+const FaceFieldZ = Field{Cell, Cell, Face}
+


### PR DESCRIPTION
Just stealing the staggered grid field types from Oceananigans. We ended up defining the field location using parametric types `{LX, LY, LZ}` so we can dispatch on them as needed.

You'll notice that I've just defined types and no constructors because the Oceananigans constructors dispatch on other structs like an `AbstractArchitecture` (CPU vs. GPU) and an overloaded `zeros` function. We can define CPU constructors for now, but might not make sense to define JULES `architectures` until we can support more than one.