### PR TITLE
Acoustic and advective CFL utilities

### DIFF
--- a/src/JULES.jl
+++ b/src/JULES.jl
@@ -21,5 +21,6 @@ include("models.jl")
 include("right_hand_sides.jl")
 include("time_stepping_kernels.jl")
 include("time_stepping.jl")
+include("utils.jl")
 
 end # module

--- a/src/JULES.jl
+++ b/src/JULES.jl
@@ -9,7 +9,8 @@ export
     Temperature, ModifiedPotentialTemperature, Entropy,
     IdealGas,
     CompressibleModel,
-    time_step!
+    time_step!,
+    cfl
 
 include("Operators/Operators.jl")
 

--- a/src/JULES.jl
+++ b/src/JULES.jl
@@ -10,7 +10,7 @@ export
     IdealGas,
     CompressibleModel,
     time_step!,
-    cfl
+    cfl, acoustic_cfl
 
 include("Operators/Operators.jl")
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,0 +1,19 @@
+function cfl(model)
+    grid = model.grid
+    Nx, Ny, Nz = grid.Nx, grid.Ny, grid.Nz
+    Δx, Δy, Δz = grid.Δx, grid.Δy, grid.Δz
+
+    ρ = model.density
+    ρu, ρv, ρw = model.momenta
+
+    ρ, ρu, ρv, ρw = ρ.data, ρu.data, ρv.data, ρw.data
+
+    u_max = v_max = w_max = 0
+    for k in 1:Nz, j in 1:Ny, i in 1:Nx
+        u_max = max(u_max, abs(ρu[i, j, k] / ρ[i, j, k]))
+        v_max = max(v_max, abs(ρv[i, j, k] / ρ[i, j, k]))
+        w_max = max(w_max, abs(ρw[i, j, k] / ρ[i, j, k]))
+    end
+
+    return min(Δx/u_max, Δy/v_max, Δz/w_max)
+end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -17,3 +17,23 @@ function cfl(model, Δt)
 
     return Δt / min(Δx/u_max, Δy/v_max, Δz/w_max)
 end
+
+function acoustic_cfl(model, Δt)
+    grid = model.grid
+    Nx, Ny, Nz = grid.Nx, grid.Ny, grid.Nz
+    Δx, Δy, Δz = grid.Δx, grid.Δy, grid.Δz
+    ρ, Θ = model.density.data, model.tracers.Θᵐ.data
+    gas = model.buoyancy
+    R = gas_constant
+    M = molar_mass_dry_air
+
+    c_max = 0
+    for k in 1:Nz, j in 1:Ny, i in 1:Nx
+        π = Π(i, j, k, grid, gas, Θ)
+        T = π * (Θ[i, j, k] / ρ[i, j, k])
+        c = √(gas.γ * R * T / M)
+        c_max = max(c_max, c)
+    end
+    
+    return Δt / min(Δx/c_max, Δy/c_max, Δz/c_max)
+end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,4 +1,4 @@
-function cfl(model)
+function cfl(model, Δt)
     grid = model.grid
     Nx, Ny, Nz = grid.Nx, grid.Ny, grid.Nz
     Δx, Δy, Δz = grid.Δx, grid.Δy, grid.Δz
@@ -15,5 +15,5 @@ function cfl(model)
         w_max = max(w_max, abs(ρw[i, j, k] / ρ[i, j, k]))
     end
 
-    return min(Δx/u_max, Δy/v_max, Δz/w_max)
+    return Δt / min(Δx/u_max, Δy/v_max, Δz/w_max)
 end

--- a/verification/dry_rising_thermal_bubble/dry_rising_thermal_bubble.jl
+++ b/verification/dry_rising_thermal_bubble/dry_rising_thermal_bubble.jl
@@ -79,9 +79,12 @@ set!(model.tracers.Θᵐ, Θ₀)
 ##### Run a dry adiabatic atmosphere to hydrostatic balance
 #####
 
+Δt = 0.2
 while model.clock.time < 500
-    @printf("t = %.2f s\n", model.clock.time)
-    time_step!(model, Δt=0.2, Nt=100)
+    CFL = cfl(model, Δt)
+    aCFL = acoustic_cfl(model, Δt)
+    @printf("t = %.2f s, CFL = %.2e, aCFL = %.2e\n", model.clock.time, CFL, aCFL)
+    time_step!(model, Δt=Δt, Nt=100)
 end
 
 #####
@@ -114,10 +117,14 @@ savefig(Θ_plot, "theta_initial_condition.png")
 ##### Watch the thermal bubble rise!
 #####
 
+Δt=0.1
 for n in 1:200
-    time_step!(model, Δt=0.1, Nt=50)
+    time_step!(model, Δt=Δt, Nt=50)
 
-    @printf("t = %.2f s\n", model.clock.time)
+    CFL = cfl(model, Δt)
+    aCFL = acoustic_cfl(model, Δt)
+    @printf("t = %.2f s, CFL = %.2e, aCFL = %.2e\n", model.clock.time, CFL, aCFL)
+
     xC, yC, zC = model.grid.xC ./ km, model.grid.yC ./ km, model.grid.zC ./ km
     xF, yF, zF = model.grid.xF ./ km, model.grid.yF ./ km, model.grid.zF ./ km
 


### PR DESCRIPTION
We can now calculate acoustic and advective CFL numbers.

Should be useful, especially for debugging acoustic time steppers, and adaptive time stepping.

Right now the dry rising thermal bubble verification experiment runs at acoustic CFL ~ 0.5 and advective CFL ~ 0.005 so with acoustic time stepping we should be able to increase RK time steps for this simulation by a factor of ~200 and still maintain advective CFL < 1.

Resolves #34 