### PR TITLE
Simplify verification experiments using lazy fields

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -97,6 +97,12 @@ git-tree-sha1 = "ed2c4abadf84c53d9e58510b5fc48912c2336fbb"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
 version = "2.2.0"
 
+[[CompilerSupportLibraries_jll]]
+deps = ["Libdl", "Pkg"]
+git-tree-sha1 = "b57c5d019367c90f234a7bc7e24ff0a84971da5d"
+uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
+version = "0.2.0+1"
+
 [[Conda]]
 deps = ["JSON", "VersionParsing"]
 git-tree-sha1 = "7a58bb32ce5d85f8bf7559aa7c2842f9aecf52fc"
@@ -134,9 +140,9 @@ version = "1.1.0"
 
 [[DataStructures]]
 deps = ["InteractiveUtils", "OrderedCollections"]
-git-tree-sha1 = "b7720de347734f4716d1815b00ce5664ed6bbfd4"
+git-tree-sha1 = "5a431d46abf2ef2a4d5d00bd0ae61f651cf854c8"
 uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
-version = "0.17.9"
+version = "0.17.10"
 
 [[Dates]]
 deps = ["Printf"]
@@ -199,9 +205,9 @@ version = "0.44.0"
 
 [[GeometryTypes]]
 deps = ["ColorTypes", "FixedPointNumbers", "LinearAlgebra", "StaticArrays"]
-git-tree-sha1 = "a96baa00f5ac755689c82c29bc3395e161337c69"
+git-tree-sha1 = "78f0ce9d01993b637a8f28d84537d75dc0ce8eef"
 uuid = "4d00f742-c7ba-57c2-abde-4428a4b178cb"
-version = "0.7.7"
+version = "0.7.10"
 
 [[Glob]]
 deps = ["Compat", "Test"]
@@ -340,16 +346,16 @@ version = "0.4.3"
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
 
 [[NCDatasets]]
-deps = ["BinDeps", "CFTime", "Compat", "CondaBinDeps", "DataStructures", "Dates", "Libdl", "Missings", "Printf", "Random"]
-git-tree-sha1 = "e1af72822f9ebbb70e61d084a070f07fb3a43b23"
+deps = ["BinDeps", "CFTime", "CondaBinDeps", "DataStructures", "Dates", "Libdl", "Printf"]
+git-tree-sha1 = "2ca1db7b3ffb95bc7ff68df2c94ad5755ed6245b"
 uuid = "85f8d34a-cbdd-5861-8df4-14fed0d494ab"
-version = "0.9.4"
+version = "0.10.0"
 
 [[NNlib]]
 deps = ["BinaryProvider", "Libdl", "LinearAlgebra", "Requires", "Statistics"]
-git-tree-sha1 = "755c0bab3912ff782167e1b4b774b833f8a0e550"
+git-tree-sha1 = "21a3c22bc197b6ae2f8d4d75631876e2b6506dbe"
 uuid = "872c559c-99b0-510c-b3b7-b6c96a88d5cd"
-version = "0.6.4"
+version = "0.6.5"
 
 [[NaNMath]]
 git-tree-sha1 = "928b8ca9b2791081dc71a51c55347c27c618760f"
@@ -358,11 +364,9 @@ version = "0.3.3"
 
 [[Oceananigans]]
 deps = ["Adapt", "CUDAapi", "CUDAdrv", "CUDAnative", "CuArrays", "Dates", "FFTW", "GPUifyLoops", "JLD2", "LinearAlgebra", "Logging", "NCDatasets", "OffsetArrays", "OrderedCollections", "Printf", "Random", "Statistics", "Test"]
-git-tree-sha1 = "a3a5e91c23cc943cab9fd24ccf22c3e44ef6e8c4"
-repo-rev = "master"
-repo-url = "https://github.com/climate-machine/Oceananigans.jl.git"
+git-tree-sha1 = "d0df416a725feb7380390cab972cb02071270647"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
-version = "0.23.0"
+version = "0.24.1"
 
 [[OffsetArrays]]
 git-tree-sha1 = "707e34562700b81e8aa13548eb6b23b18112e49b"
@@ -370,10 +374,10 @@ uuid = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 version = "1.0.2"
 
 [[OpenSpecFun_jll]]
-deps = ["Libdl", "Pkg"]
-git-tree-sha1 = "65f672edebf3f4e613ddf37db9dcbd7a407e5e90"
+deps = ["CompilerSupportLibraries_jll", "Libdl", "Pkg"]
+git-tree-sha1 = "d110040968b9afe95c6bd9c6233570b0fe8abd22"
 uuid = "efe28fd5-8261-553b-a9e1-b2916fc3738e"
-version = "0.5.3+1"
+version = "0.5.3+2"
 
 [[OrderedCollections]]
 deps = ["Random", "Serialization", "Test"]
@@ -389,9 +393,9 @@ version = "0.5.1"
 
 [[Parsers]]
 deps = ["Dates", "Test"]
-git-tree-sha1 = "d112c19ccca00924d5d3a38b11ae2b4b268dda39"
+git-tree-sha1 = "0c16b3179190d3046c073440d94172cfc3bb0553"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "0.3.11"
+version = "0.3.12"
 
 [[Pkg]]
 deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
@@ -560,9 +564,9 @@ version = "0.6.10"
 
 [[WoodburyMatrices]]
 deps = ["LinearAlgebra", "SparseArrays"]
-git-tree-sha1 = "bbb9f7fd6fbdd9582e77c0b698312c543de5eb71"
+git-tree-sha1 = "68f000f67654d07318d734b364a31233e465f49a"
 uuid = "efce3f68-66dc-5838-9240-27a6d6f5f9b6"
-version = "0.5.0"
+version = "0.5.1"
 
 [[Zlib_jll]]
 deps = ["Libdl", "Pkg"]

--- a/src/Operators/compressible_operators.jl
+++ b/src/Operators/compressible_operators.jl
@@ -2,10 +2,10 @@
 ##### Legend:
 ##### ρ  -> density fields
 ##### ρũ -> momentum fields
+#####  ũ -> velocity fields
 ##### ρc̃ -> conservative tracer fields
-##### K̃  -> diffusivity fields
-##### ũ  -> velocity fields
-##### c̃  -> tracer fields
+#####  c̃ -> tracer fields
+#####  K̃ -> diffusivity fields
 #####
 
 #####

--- a/src/compressible_model.jl
+++ b/src/compressible_model.jl
@@ -6,13 +6,15 @@ using Oceananigans.Forcing: zeroforcing
 ##### Definition of a compressible model
 #####
 
-mutable struct CompressibleModel{A, FT, Ω, D, M, T, K, Θ, G, X, C, P, F, S, R, I, W} <: AbstractModel
+mutable struct CompressibleModel{A, FT, Ω, D, M, V, T, L, K, Θ, G, X, C, P, F, S, R, I, W} <: AbstractModel
               architecture :: A
                       grid :: Ω
                      clock :: Clock{FT}
              total_density :: D
                    momenta :: M
+                velocities :: V
                    tracers :: T
+              lazy_tracers :: L
              diffusivities :: K
     thermodynamic_variable :: Θ
                      gases :: G
@@ -61,10 +63,14 @@ function CompressibleModel(;
     closure = with_tracers(tracernames, closure)
     total_density = CellField(architecture, grid)
 
+    velocities = LazyVelocityFields(architecture, grid, total_density, momenta)
+    lazy_tracers = LazyTracerFields(architecture, grid, total_density, tracers)
+
     return CompressibleModel(
-        architecture, grid, clock, total_density, momenta, tracers, diffusivities,
-        thermodynamic_variable, gases, gravity, coriolis, closure, microphysics,
-        forcing, slow_forcings, right_hand_sides, intermediate_variables, acoustic_time_stepper)
+        architecture, grid, clock, total_density, momenta, velocities, tracers,
+        lazy_tracers, diffusivities, thermodynamic_variable, gases, gravity,
+        coriolis, closure, microphysics, forcing, slow_forcings, right_hand_sides,
+        intermediate_variables, acoustic_time_stepper)
 end
 
 using Oceananigans.Grids: short_show

--- a/src/lazy_fields.jl
+++ b/src/lazy_fields.jl
@@ -27,16 +27,16 @@ LazyPrimitiveField(LX, LY, LZ, arch, grid, ρϕ, ρ) =
     @inbounds f.conservative_field[I...] / ℑzᵃᵃᶠ(I..., f.grid, f.density)
 
 LazyVelocityFields(arch, grid, ρ, ρũ) =
-    (u = LazyPrimitiveField(Face, Cell, Cell, arch, grid, ρũ.ρu.data, ρ.data),
-     v = LazyPrimitiveField(Cell, Face, Cell, arch, grid, ρũ.ρv.data, ρ.data),
-     w = LazyPrimitiveField(Cell, Cell, Face, arch, grid, ρũ.ρw.data, ρ.data))
+    (u = LazyPrimitiveField(Face, Cell, Cell, arch, grid, ρũ.ρu, ρ),
+     v = LazyPrimitiveField(Cell, Face, Cell, arch, grid, ρũ.ρv, ρ),
+     w = LazyPrimitiveField(Cell, Cell, Face, arch, grid, ρũ.ρw, ρ))
 
 function LazyTracerFields(arch, grid, ρ, ρc̃)
     c_names = [filter(c -> c != 'ρ', string(c)) for c in keys(ρc̃)]
     c_names = filter(s -> s != "", c_names) .|> Symbol |> Tuple  # Don't include the ρ tracer.
 
     c_fields = Tuple(
-        LazyPrimitiveField(Cell, Cell, Cell, arch, grid, getproperty(ρc̃, Symbol(:ρ, c)).data, ρ.data)
+        LazyPrimitiveField(Cell, Cell, Cell, arch, grid, getproperty(ρc̃, Symbol(:ρ, c)), ρ)
         for c in c_names
     )
 

--- a/src/lazy_fields.jl
+++ b/src/lazy_fields.jl
@@ -1,5 +1,7 @@
-using Base: @propagate_inbounds
 import Base: getindex
+import Oceananigans.Fields: interior, interiorparent
+
+using Base: @propagate_inbounds
 
 using Oceananigans.Operators: ℑxᶠᵃᵃ, ℑyᵃᶠᵃ, ℑzᵃᵃᶠ
 using Oceananigans.Fields
@@ -42,3 +44,13 @@ function LazyTracerFields(arch, grid, ρ, ρc̃)
 
     return NamedTuple{c_names}(c_fields)
 end
+
+function interior(f::LazyPrimitiveField)
+    data = zeros(size(f.conservative_field))
+    for k in 1:f.grid.Nz, j in 1:f.grid.Ny, i in 1:f.grid.Nx
+        data[i, j, k] = f[i, j, k]
+    end
+    return data
+end
+
+interiorparent(lf::LazyPrimitiveField) = interior(lf)

--- a/test/test_regression.jl
+++ b/test/test_regression.jl
@@ -48,7 +48,7 @@ end
 
             field_names = [:ρ, :ρu, :ρv, :ρw]
             fields = [interior(model.total_density), interior(model.momenta.ρu),
-                      interior(model.momenta.ρv), interior(model.momenta.ρw)]
+                      interior(model.momenta.ρv), interior(model.momenta.ρw)[:, :, 1:end-1]]
             correct_fields = [file["ρ"], file["ρu"], file["ρv"], file["ρw"]]
 
             if tvar isa Energy
@@ -67,7 +67,7 @@ end
 
             @test all(interior(model.total_density) .≈ file["ρ"])
             @test all(interior(model.momenta.ρv)    .≈ file["ρv"])
-            @test all(interior(model.momenta.ρw)    .≈ file["ρw"])
+            @test all(interior(model.momenta.ρw)[:, :, 1:end-1]    .≈ file["ρw"])
             if tvar isa Energy
                 @test all(interior(model.tracers.ρe) .≈ file["ρe"])
             elseif tvar isa Entropy
@@ -109,7 +109,7 @@ end
 
             field_names = [:ρ, :ρu, :ρv, :ρw, :ρ₁, :ρ₂, :ρ₃]
             fields = [interior(model.total_density), interior(model.momenta.ρu),
-                      interior(model.momenta.ρv), interior(model.momenta.ρw),
+                      interior(model.momenta.ρv), interior(model.momenta.ρw)[:, :, 1:end-1],
                       interior(model.tracers.ρ₁), interior(model.tracers.ρ₂),
                       interior(model.tracers.ρ₃)]
             correct_fields = [file["ρ"], file["ρu"], file["ρv"], file["ρw"],
@@ -131,7 +131,7 @@ end
 
             @test all(interior(model.total_density) .≈ file["ρ"])
             @test all(interior(model.momenta.ρv)    .≈ file["ρv"])
-            @test all(interior(model.momenta.ρw)    .≈ file["ρw"])
+            @test all(interior(model.momenta.ρw)[:, :, 1:end-1]    .≈ file["ρw"])
             @test all(interior(model.tracers.ρ₁)    .≈ file["ρ₁"])
             @test all(interior(model.tracers.ρ₂)    .≈ file["ρ₂"])
             @test all(interior(model.tracers.ρ₃)    .≈ file["ρ₃"])

--- a/verification/three_gas_dry_rising_thermal_bubble/three_gas_dry_rising_thermal_bubble.jl
+++ b/verification/three_gas_dry_rising_thermal_bubble/three_gas_dry_rising_thermal_bubble.jl
@@ -118,8 +118,8 @@ function simulate_three_gas_dry_rising_thermal_bubble(;
     ρ₁ʰᵈ = interiorxz(model.tracers.ρ₁)
     ρ₂ʰᵈ = interiorxz(model.tracers.ρ₂)
     ρ₃ʰᵈ = interiorxz(model.tracers.ρ₃)
-    tvar isa Energy  && (ρeʰᵈ = interiorxz(model.tracers.ρe))
-    tvar isa Entropy && (ρsʰᵈ = interiorxz(model.tracers.ρs))
+    tvar isa Energy  && (eʰᵈ = interiorxz(model.lazy_tracers.e))
+    tvar isa Entropy && (sʰᵈ = interiorxz(model.lazy_tracers.s))
 
     # Set initial state (which includes the thermal perturbation)
     set!(model.tracers.ρ₁, ρ₁ᵢ)
@@ -137,12 +137,12 @@ function simulate_three_gas_dry_rising_thermal_bubble(;
         savefig(ρ_plot, "rho_prime_initial_condition_with_$(typeof(tvar)).png")
 
         if tvar isa Energy
-            e_slice = rotr90(interiorxz(model.tracers.ρe) ./ interiorxz(model.total_density))
+            e_slice = rotr90(interiorxz(model.lazy_tracers.e))
             e_plot = contour(model.grid.xC ./ km, model.grid.zC ./ km, e_slice,
                              fill=true, levels=10, xlims=(-5, 5), color=:thermal, dpi=200)
             savefig(e_plot, "energy_initial_condition.png")
         elseif tvar isa Entropy
-            s_slice = rotr90(interiorxz(model.tracers.ρs) ./ interiorxz(model.total_density))
+            s_slice = rotr90(interiorxz(model.lazy_tracers.s))
             s_plot = contour(model.grid.xC ./ km, model.grid.zC ./ km, s_slice,
                              fill=true, levels=10, xlims=(-5, 5), color=:thermal, dpi=200)
             savefig(s_plot, "entropy_initial_condition.png")
@@ -159,7 +159,7 @@ function simulate_three_gas_dry_rising_thermal_bubble(;
     tvar isa Entropy && (ρ̄s̄ᵢ = sum(interior(model.tracers.ρs)) / (Nx*Ny*Nz))
 
     if tvar isa Energy
-        sim_parameters = (make_plots=make_plots, ρʰᵈ=ρʰᵈ, ρeʰᵈ=ρeʰᵈ, ρ̄ᵢ=ρ̄ᵢ, ρ̄ēᵢ=ρ̄ēᵢ)
+        sim_parameters = (make_plots=make_plots, ρʰᵈ=ρʰᵈ, eʰᵈ=eʰᵈ, ρ̄ᵢ=ρ̄ᵢ, ρ̄ēᵢ=ρ̄ēᵢ)
     elseif tvar isa Entropy
         sim_parameters = (make_plots=make_plots, ρʰᵈ=ρʰᵈ, ρ̄ᵢ=ρ̄ᵢ, ρ̄s̄ᵢ=ρ̄s̄ᵢ)
     end
@@ -191,7 +191,7 @@ function print_progress_and_make_plots(simulation)
     Nx, Ny, Nz = model.grid.Nx, model.grid.Ny, model.grid.Nz
 
     if tvar isa Energy
-        make_plots, ρʰᵈ, ρeʰᵈ, ρ̄ᵢ, ρ̄ēᵢ = simulation.parameters
+        make_plots, ρʰᵈ, eʰᵈ, ρ̄ᵢ, ρ̄ēᵢ = simulation.parameters
     elseif tvar isa Entropy
         make_plots, ρʰᵈ, ρ̄ᵢ, ρ̄s̄ᵢ = simulation.parameters
     end
@@ -241,11 +241,11 @@ function print_progress_and_make_plots(simulation)
                           xlims=(-3, 3), color=:balance, linecolor=nothing, clims=(-0.007, 0.007))
 
         if tvar isa Energy
-            e′_slice = rotr90((interiorxz(model.tracers.ρe) .- ρeʰᵈ) ./ interiorxz(model.total_density))
+            e′_slice = rotr90((interiorxz(model.lazy_tracers.e) .- eʰᵈ))
             tvar_plot = heatmap(xC, zC, e′_slice, title="e_prime", fill=true, levels=50,
                                 xlims=(-3, 3), color=:oxy_r, linecolor=nothing, clims=(0, 1200))
         elseif tvar isa Entropy
-            s_slice = rotr90(interiorxz(model.tracers.ρs) ./ interiorxz(model.total_density))
+            s_slice = rotr90(interiorxz(model.lazy_tracers.s))
             tvar_plot = heatmap(xC, zC, s_slice, title="s", fill=true, levels=50,
                                 xlims=(-3, 3), color=:oxy_r, linecolor=nothing, clims=(100, 300))
         end


### PR DESCRIPTION
Also upgraded to Oceananigans v0.24.1 which introduces some breaking changes like face fields having N+1 grid points in bounded dimensions, i.e. w has size `N * N * N+1` (see https://github.com/climate-machine/Oceananigans.jl/pull/644), so I had to revise the regression tests.