### PR TITLE
Better and more benchmarks

### DIFF
--- a/benchmarks/benchmark_cfl.jl
+++ b/benchmarks/benchmark_cfl.jl
@@ -25,6 +25,11 @@ suite = BenchmarkGroup(
     "acoustic_cfl" => BenchmarkGroup()
 )
 
+_cfl(model) = cfl(model, 1)
+_cfl(model::CompressibleModel{GPU}) = CUDA.@sync cfl(model, 1)
+_acoustic_cfl(model) = acoustic_cfl(model, 1)
+_acoustic_cfl(model::CompressibleModel{GPU}) = CUDA.@sync acoustic_cfl(model, 1)
+
 for Arch in Archs, N in Ns, Gas in Gases, Tvar in Tvars
     @info "Running CFL benchmark [$Arch, N=$N, $Tvar, $Gas]..."
 
@@ -33,13 +38,13 @@ for Arch in Archs, N in Ns, Gas in Gases, Tvar in Tvars
                               gases=Gas())
 
     # warmup
-    cfl(model, 1)
-    acoustic_cfl(model, 1)
+    _cfl(model)
+    _acoustic_cfl(model)
 
-    b_cfl = @benchmark cfl($model, 1) samples=10
+    b_cfl = @benchmark _cfl($model) samples=10
     display(b_cfl)
 
-    b_acfl = @benchmark acoustic_cfl($model, 1) samples=10
+    b_acfl = @benchmark _acoustic_cfl($model) samples=10
     display(b_acfl)
 
     key = (Arch, N, Gas, Tvar)

--- a/benchmarks/benchmark_cfl.jl
+++ b/benchmarks/benchmark_cfl.jl
@@ -26,7 +26,7 @@ suite = BenchmarkGroup(
 )
 
 for Arch in Archs, N in Ns, Gas in Gases, Tvar in Tvars
-    @info "Running CFL benchmark [$Arch, N=$N, $Tvar, $Gases]..."
+    @info "Running CFL benchmark [$Arch, N=$N, $Tvar, $Gas]..."
 
     grid = RegularCartesianGrid(size=(N, N, N), extent=(1, 1, 1))
     model = CompressibleModel(architecture=Arch(), grid=grid, thermodynamic_variable=Tvar(),
@@ -42,7 +42,7 @@ for Arch in Archs, N in Ns, Gas in Gases, Tvar in Tvars
     b_acfl = @benchmark acoustic_cfl($model, 1) samples=10
     display(b_acfl)
 
-    key = (Arch, N, Gases, Tvar)
+    key = (Arch, N, Gas, Tvar)
     suite["cfl"][key] = b_cfl
     suite["acoustic_cfl"][key] = b_acfl
 end

--- a/benchmarks/benchmark_cfl.jl
+++ b/benchmarks/benchmark_cfl.jl
@@ -1,0 +1,41 @@
+using BenchmarkTools
+
+using Oceananigans
+using Oceananigans.Architectures
+using JULES
+
+Archs = [CPU]
+Ns = [32]
+Tvars = [Energy, Entropy]
+Gases = [DryEarth, DryEarth3]
+
+tags = ["arch", "N", "gases", "tvar"]
+
+suite = BenchmarkGroup(
+    "cfl" => BenchmarkGroup(),
+    "acoustic_cfl" => BenchmarkGroup()
+)
+
+for Arch in Archs, N in Ns, Gases in Gases, Tvar in Tvars
+    @info "Running CFL benchmark [$Arch, N=$N, $Tvar, $Gases]..."
+
+    grid = RegularCartesianGrid(size=(N, N, N), extent=(1, 1, 1))
+    model = CompressibleModel(architecture=Arch(), grid=grid, thermodynamic_variable=Tvar(),
+                              gases=Gases())
+
+    # warmup
+    cfl(model, 1)
+    acoustic_cfl(model, 1)
+
+    b_cfl = @benchmark cfl($model, 1) samples=10
+    display(b_cfl)
+
+    b_acfl = @benchmark acoustic_cfl($model, 1) samples=10
+    display(b_acfl)
+
+    key = (Arch, N, Gases, Tvar)
+    suite["cfl"][key] = b_cfl
+    suite["acoustic_cfl"][key] = b_acfl
+end
+
+

--- a/benchmarks/benchmark_diagnosis.jl
+++ b/benchmarks/benchmark_diagnosis.jl
@@ -38,7 +38,7 @@ for Arch in Archs, N in Ns, Gases in Gases, Tvar in Tvars
 
     _compute_temperature!(model) # warmup
 
-    b = @benchmark _compute_temperature!(model) samples=10
+    b = @benchmark _compute_temperature!($model) samples=10
 
     key = (Arch, N, Gases, Tvar)
     suite["temperature"][key] = b

--- a/benchmarks/benchmark_diagnosis.jl
+++ b/benchmarks/benchmark_diagnosis.jl
@@ -1,0 +1,119 @@
+using BenchmarkTools
+using DataFrames
+using PrettyTables
+
+using Oceananigans
+using Oceananigans.Architectures
+using JULES
+
+using BenchmarkTools: prettytime, prettymemory
+using JULES: intermediate_thermodynamic_field, compute_temperature!
+
+Archs = [CPU]
+@hascuda Archs = [CPU, GPU]
+
+Ns = [32, 64]
+@hascuda Ns = [32, 192]
+
+Tvars = [Energy, Entropy]
+Gases = [DryEarth, DryEarth3]
+
+tags = ["arch", "N", "gases", "tvar"]
+
+suite = BenchmarkGroup(
+    "temperature" => BenchmarkGroup(),
+    "pressure" => BenchmarkGroup()
+)
+
+function compute_temperature!(model)
+    temperature = intermediate_thermodynamic_field(model)
+
+    temperature, total_density, momenta, tracers =
+        datatuples(temperature, model.total_density, model.momenta, model.tracers)
+
+    compute_temperature_event =
+        launch!(model.architecture, model.grid, :xyz, compute_temperature!,
+                temperature, model.grid, model.thermodynamic_variable, model.gases,
+                model.gravity, total_density, momenta, tracers,
+                dependencies=Event(device(model.architecture)))
+
+    wait(device(model.architecture), compute_p_over_ρ_event)
+
+    return temperature
+end
+
+_compute_temperature!(model) = compute_temperature!(model)
+_compute_temperature!(model::CompressibleModel{GPU}) = CUDA.@sync compute_temperature!(model)
+
+for Arch in Archs, N in Ns, Gases in Gases, Tvar in Tvars
+    @info "Running temperature computation benchmark [$Arch, N=$N, $Tvar, $Gases]..."
+
+    grid = RegularCartesianGrid(size=(N, N, N), extent=(1, 1, 1))
+    model = CompressibleModel(architecture=Arch(), grid=grid, thermodynamic_variable=Tvar(),
+                              gases=Gases())
+
+    _compute_temperature!(model) # warmup
+
+    b = @benchmark _compute_temperature!(model) samples=10
+
+    key = (Arch, N, Gases, Tvar)
+    suite["temperature"][key] = b
+end
+
+function benchmarks_to_dataframe(suite)
+    df = DataFrame(architecture=[], size=[], gases=[],
+                   thermodynamic_variable=[], min=[], median=[],
+                   mean=[], max=[], memory=[], allocs=[])
+    
+    for (key, b) in suite
+        Arch, N, Gases, Tvar = key
+
+        d = Dict(
+            "architecture" => Arch,
+            "size" => "$(N)³",
+            "gases" => Gases,
+            "thermodynamic_variable" => Tvar,
+            "min" => minimum(b.times) |> prettytime,
+            "median" => median(b.times) |> prettytime,
+            "mean" => mean(b.times) |> prettytime,
+            "max" => maximum(b.times) |> prettytime,
+            "memory" => prettymemory(b.memory),
+            "allocs" => b.allocs
+        )
+
+        push!(df, d)
+    end
+
+    return df
+end
+
+header = ["Arch" "Size" "Gases" "ThermoVar" "min" "median" "mean" "max" "memory" "allocs"]
+
+df = benchmarks_to_dataframe(suite["temperature"])
+pretty_table(df, header, title="Temperature computation benchmarks", nosubheader=true)
+
+function gpu_speedups(suite)
+    df = DataFrame(size=[], gases=[], thermodynamic_variable=[], speedup=[])
+
+    for N in Ns, Gas in Gases, Tvar in Tvars
+        b_cpu = suite[CPU, N, Gas, Tvar] |> median
+        b_gpu = suite[GPU, N, Gas, Tvar] |> median
+        b_ratio = ratio(b_cpu, b_gpu)
+
+        d = Dict(
+            "size" => "$(N)³",
+            "gases" => Gas,
+            "thermodynamic_variable" => Tvar,
+            "speedup" => @sprintf("%.3fx", b_ratio.time)
+        )
+
+        push!(df, d)
+    end
+
+    return df
+end
+
+header = ["Size" "Gases" "ThermoVar" "speedup"]
+
+df = gpu_speedups(suite["temperature"])
+pretty_table(df, header, title="Temperature computation speedups", nosubheader=true)

--- a/benchmarks/benchmark_static_atmosphere.jl
+++ b/benchmarks/benchmark_static_atmosphere.jl
@@ -1,32 +1,95 @@
 using Printf
-using TimerOutputs
+
+using BenchmarkTools
+using CUDA
+using DataFrames
+using PrettyTables
 
 using Oceananigans
 using Oceananigans.Architectures
 using JULES
 
-const timer = TimerOutput()
-
-Ns = (32, 256)
-Tvars = (Energy, Entropy)
-Gases = (DryEarth, DryEarth3)
+using BenchmarkTools: prettytime, prettymemory
 
 Archs = [CPU]
 @hascuda Archs = [CPU, GPU]
 
-for Arch in Archs, N in Ns, Tvar in Tvars, Gas in Gases
+Ns = [32, 192]
+Tvars = [Energy, Entropy]
+Gases = [DryEarth, DryEarth3]
 
-    bname = "$N×$N×$N [$Arch, $Tvar, $Gas]"
-    @info "Benchmarking $bname..."
+suite = BenchmarkGroup()
 
-    grid = RegularCartesianGrid(size=(N, N, N), extent=(1, 1, 1), halo=(2, 2, 2))
+for Arch in Archs, N in Ns, Gas in Gases, Tvar in Tvars
+    @info "Running static atmosphere benchmark [$Arch, N=$N, $Tvar, $Gas]..."
+
+    grid = RegularCartesianGrid(size=(N, N, N), halo=(2, 2, 2), extent=(1, 1, 1))
     model = CompressibleModel(architecture=Arch(), grid=grid, thermodynamic_variable=Tvar(), gases=Gas())
-    time_step!(model, 1)  # warmup to compile
 
-    for i in 1:10
-        @timeit timer bname time_step!(model, 1)
-    end
+    # warmup
+    time_step!(model, 1)
 
+    b = @benchmark time_step!($model, 1) samples=10
+    display(b)
+
+    key = (Arch, N, Gas, Tvar)
+    suite[key] = b
 end
 
-print_timer(timer, title="Static atmosphere benchmarks", sortby=:name)
+function benchmarks_to_dataframe(suite)
+    df = DataFrame(architecture=[], size=[], gases=[],
+                   thermodynamic_variable=[], min=[], median=[],
+                   mean=[], max=[], memory=[], allocs=[])
+    
+    for Arch in Archs, N in Ns, Gas in Gases, Tvar in Tvars
+        b = suite[Arch, N, Gas, Tvar]
+
+        d = Dict(
+            "architecture" => Arch,
+            "size" => "$(N)³",
+            "gases" => Gas,
+            "thermodynamic_variable" => Tvar,
+            "min" => minimum(b.times) |> prettytime,
+            "median" => median(b.times) |> prettytime,
+            "mean" => mean(b.times) |> prettytime,
+            "max" => maximum(b.times) |> prettytime,
+            "memory" => prettymemory(b.memory),
+            "allocs" => b.allocs
+        )
+
+        push!(df, d)
+    end
+
+    return df
+end
+
+header = ["Arch" "Size" "Gases" "ThermoVar" "min" "median" "mean" "max" "memory" "allocs"]
+
+df = benchmarks_to_dataframe(suite)
+pretty_table(df, header, title="Static atmosphere benchmarks", nosubheader=true)
+
+function gpu_speedups(suite)
+    df = DataFrame(size=[], gases=[], thermodynamic_variable=[], speedup=[])
+
+    for N in Ns, Gas in Gases, Tvar in Tvars
+        b_cpu = suite[CPU, N, Gas, Tvar] |> median
+        b_gpu = suite[GPU, N, Gas, Tvar] |> median
+        b_ratio = ratio(b_cpu, b_gpu)
+
+        d = Dict(
+            "size" => "$(N)³",
+            "gases" => Gas,
+            "thermodynamic_variable" => Tvar,
+            "speedup" => @sprintf("%.3fx", b_ratio.time)
+        )
+
+        push!(df, d)
+    end
+
+    return df
+end
+
+header = ["Size" "Gases" "ThermoVar" "speedup"]
+
+df = gpu_speedups(suite)
+pretty_table(df, header, title="Static atmosphere speedups", nosubheader=true)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -52,9 +52,9 @@ function cfl(model, Δt)
     
     wait(device(model.architecture), velocity_event)
 
-    u_max = maximum(velocities.u)
-    v_max = maximum(velocities.v)
-    w_max = maximum(velocities.w)
+    u_max = maximum(velocities.u.parent)
+    v_max = maximum(velocities.v.parent)
+    w_max = maximum(velocities.w.parent)
 
     Δx, Δy, Δz = model.grid.Δx, model.grid.Δy, model.grid.Δz
     CFL = Δt / min(Δx/u_max, Δy/v_max, Δz/w_max)
@@ -81,7 +81,7 @@ function acoustic_cfl(model, Δt)
 
     wait(device(model.architecture), compute_p_over_ρ_event)
 
-    p_over_ρ_max = maximum(p_over_ρ)
+    p_over_ρ_max = maximum(p_over_ρ.parent)
 
     γ_max = maximum(gas.cₚ / gas.cᵥ for gas in model.gases)
     c_max = √(γ_max * p_over_ρ_max)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -30,6 +30,12 @@ end
     @inbounds p_over_ρ[i, j, k] = diagnose_p_over_ρ(i, j, k, grid, thermodynamic_variable, gases, gravity, total_density, momenta, tracers)
 end
 
+@kernel function compute_temperature!(i, j, k, grid, thermodynamic_variable, gases, gravity, total_density, momenta, tracers)
+    i, j, k = @index(Global, NTuple)
+
+    @inbounds temperature[i, j, k] = diagnose_temperature(i, j, k, grid, thermodynamic_variable, gases, gravity, total_density, momenta, tracers)
+end
+
 #####
 ##### CFL
 #####

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -30,7 +30,7 @@ end
     @inbounds p_over_ρ[i, j, k] = diagnose_p_over_ρ(i, j, k, grid, thermodynamic_variable, gases, gravity, total_density, momenta, tracers)
 end
 
-@kernel function compute_temperature!(i, j, k, grid, thermodynamic_variable, gases, gravity, total_density, momenta, tracers)
+@kernel function compute_temperature!(temperature, grid, thermodynamic_variable, gases, gravity, total_density, momenta, tracers)
     i, j, k = @index(Global, NTuple)
 
     @inbounds temperature[i, j, k] = diagnose_temperature(i, j, k, grid, thermodynamic_variable, gases, gravity, total_density, momenta, tracers)
@@ -48,7 +48,7 @@ function compute_temperature!(model)
                 model.gravity, total_density, momenta, tracers,
                 dependencies=Event(device(model.architecture)))
 
-    wait(device(model.architecture), compute_p_over_ρ_event)
+    wait(device(model.architecture), compute_temperature_event)
 
     return temperature
 end

--- a/test/test_regression.jl
+++ b/test/test_regression.jl
@@ -95,7 +95,7 @@ for Arch in Archs
                 @info "  Testing three gas thermal bubble regression [$Tvar, $Arch]..."
 
                 simulation = simulate_three_gas_dry_rising_thermal_bubble(architecture = Arch(),
-                    end_time=4.999, thermodynamic_variable=Tvar(), make_plots=false)
+                    end_time=4.999, thermodynamic_variable=Tvar())
 
                 model = simulation.model
                 regression_filepath = "three_gas_thermal_bubble_regression_$Tvar.jld2"

--- a/verification/dry_rising_thermal_bubble/animate_dry_rising_thermal_bubble.jl
+++ b/verification/dry_rising_thermal_bubble/animate_dry_rising_thermal_bubble.jl
@@ -36,22 +36,26 @@ for n in 1:length(ds["time"])
     ax_u = axes[1, 1]
     im = ax_u.pcolormesh(xF, zC, ρu ./ ρ, cmap=cmocean.cm.balance, vmin=-10, vmax=10)
     ax_u.set_title("u(x, z)")
-    fig.colorbar(im, ax=ax_u)
+    ax_u.set_ylabel("z (km)")
+    fig.colorbar(im, ax=ax_u, label="m/s")
 
     ax_w = axes[1, 2]
     im = ax_w.pcolormesh(xC, zC, ρw ./ ρ, cmap=cmocean.cm.balance, vmin=-10, vmax=10)
     ax_w.set_title("w(x, z)")
-    fig.colorbar(im, ax=ax_w)
+    fig.colorbar(im, ax=ax_w, label="m/s")
 
     ax_ρ = axes[2, 1]
-    im = ax_ρ.pcolormesh(xC, zC, ρ - ρ₀, cmap=cmocean.cm.dense, vmin=-0.007, vmax=0.007)
+    im = ax_ρ.pcolormesh(xC, zC, ρ - ρ₀, cmap=cmocean.cm.dense, vmin=-0.007, vmax=0)
+    ax_ρ.set_xlabel("x (km)")
+    ax_ρ.set_ylabel("z (km)")
     ax_ρ.set_title("ρ′(x, z)")
-    fig.colorbar(im, ax=ax_ρ)
+    fig.colorbar(im, ax=ax_ρ, label="kg/m³")
 
     ax_e = axes[2, 2]
-    im = ax_e.pcolormesh(xC, zC, (ρe .- ρe₀) ./ ρ, cmap=cmocean.cm.thermal, vmin=0, vmax=1200)
+    im = ax_e.pcolormesh(xC, zC, (ρe .- ρe₀) ./ ρ, cmap=cmocean.cm.thermal, vmin=0, vmax=600)
+    ax_e.set_xlabel("x (km)")
     ax_e.set_title("e′(x, z)")
-    fig.colorbar(im, ax=ax_e)
+    fig.colorbar(im, ax=ax_e, extend="max", label="J/kg")
 
     plt.xlim(-10, 10)
     plt.ylim(0, 10)

--- a/verification/dry_rising_thermal_bubble/dry_rising_thermal_bubble.jl
+++ b/verification/dry_rising_thermal_bubble/dry_rising_thermal_bubble.jl
@@ -11,6 +11,8 @@ using Oceananigans.OutputWriters
 using Oceananigans.Utils
 using JULES
 
+using Oceananigans.Fields: cpudata
+
 # using Oceananigans.Architectures: @hascuda
 
 # temporary fix
@@ -124,7 +126,7 @@ function print_progress(simulation)
 
     zC = znodes(Cell, model.grid)
     ρ̄ᵢ = mean(ρᵢ.(0, 0, zC))
-    ρ̄ = mean(interior(model.total_density))
+    ρ̄ = mean(cpudata(model.total_density))
 
     progress = 100 * model.clock.time / simulation.stop_time
     message = @sprintf("[%05.2f%%] iteration = %d, time = %s, CFL = %.4e, acoustic CFL = %.4e, ρ̄ = %.4e (relΔ = %.4e)",
@@ -133,11 +135,11 @@ function print_progress(simulation)
 
     if tvar isa Energy
         ρ̄ēᵢ = mean(ρeᵢ.(0, 0, zC))
-        ρ̄ē = mean(interior(model.tracers.ρe))
+        ρ̄ē = mean(cpudata(model.tracers.ρe))
         message *= @sprintf(", ρ̄ē = %.4e (relΔ = %.4e)", ρ̄ē, (ρ̄ē - ρ̄ēᵢ)/ρ̄ē)
     elseif tvar isa Entropy
         ρ̄s̄ᵢ = mean(ρsᵢ.(0, 0, zC))
-        ρ̄s̄ = mean(interior(model.tracers.ρs))
+        ρ̄s̄ = mean(cpudata(model.tracers.ρs))
         message *= @sprintf(", ρ̄s̄ = %.4e (relΔ = %.4e)", ρ̄s̄, (ρ̄s̄ - ρ̄s̄ᵢ)/ρ̄s̄)
     end
 

--- a/verification/three_gas_dry_rising_thermal_bubble/three_gas_dry_rising_thermal_bubble.jl
+++ b/verification/three_gas_dry_rising_thermal_bubble/three_gas_dry_rising_thermal_bubble.jl
@@ -11,6 +11,8 @@ using Oceananigans.OutputWriters
 using Oceananigans.Utils
 using JULES
 
+using Oceananigans.Fields: cpudata
+
 # using Oceananigans.Architectures: @hascuda
 
 # temporary fix
@@ -164,7 +166,7 @@ function print_progress(simulation)
 
     zC = znodes(Cell, model.grid)
     ρ̄ᵢ = mean(ρᵢ.(0, 0, zC))
-    ρ̄ = mean(interior(model.total_density))
+    ρ̄ = mean(cpudata(model.total_density))
 
     progress = 100 * model.clock.time / simulation.stop_time
     message = @sprintf("[%05.2f%%] iteration = %d, time = %s, CFL = %.4e, acoustic CFL = %.4e, ρ̄ = %.4e (relΔ = %.4e)",
@@ -173,19 +175,19 @@ function print_progress(simulation)
 
     if tvar isa Energy
         ρ̄ēᵢ = mean(ρeᵢ.(0, 0, zC))
-        ρ̄ē = mean(interior(model.tracers.ρe))
+        ρ̄ē = mean(cpudata(model.tracers.ρe))
         message *= @sprintf(", ρ̄ē = %.4e (relΔ = %.4e)", ρ̄ē, (ρ̄ē - ρ̄ēᵢ) / ρ̄ē)
     elseif tvar isa Entropy
         ρ̄s̄ᵢ = mean(ρsᵢ.(0, 0, zC))
-        ρ̄s̄ = mean(interior(model.tracers.ρs))
+        ρ̄s̄ = mean(cpudata(model.tracers.ρs))
         message *= @sprintf(", ρ̄s̄ = %.4e (relΔ = %.4e)", ρ̄s̄, (ρ̄s̄ - ρ̄s̄ᵢ) / ρ̄s̄)
     end
 
     @info message
 
-    ∂tρ₁ = maximum(model.time_stepper.slow_source_terms.tracers.ρ₁.data)
-    ∂tρ₂ = maximum(model.time_stepper.slow_source_terms.tracers.ρ₂.data)
-    ∂tρ₃ = maximum(model.time_stepper.slow_source_terms.tracers.ρ₃.data)
+    ∂tρ₁ = maximum(model.time_stepper.slow_source_terms.tracers.ρ₁.data.parent)
+    ∂tρ₂ = maximum(model.time_stepper.slow_source_terms.tracers.ρ₂.data.parent)
+    ∂tρ₃ = maximum(model.time_stepper.slow_source_terms.tracers.ρ₃.data.parent)
 
     @info @sprintf("[%05.2f%%] Maximum mass tendencies from diffusion: ∂tρ₁ = %.4e, ∂tρ₂ = %.4e, ∂tρ₃ = %.4e",
                    progress, ∂tρ₁, ∂tρ₂, ∂tρ₃)


### PR DESCRIPTION
```
Static atmosphere benchmarks                                                                                                                                                                                                                                
┌──────┬──────┬───────────┬───────────┬───────────┬────────────┬────────────┬────────────┬────────────┬────────┐
│ Arch │ Size │     Gases │ ThermoVar │       min │     median │       mean │        max │     memory │ allocs │
├──────┼──────┼───────────┼───────────┼───────────┼────────────┼────────────┼────────────┼────────────┼────────┤
│  CPU │  32³ │  DryEarth │    Energy │ 30.767 ms │  30.942 ms │  31.064 ms │  31.529 ms │ 646.33 KiB │   4499 │
│  CPU │  32³ │  DryEarth │   Entropy │ 26.396 ms │  26.625 ms │  26.672 ms │  27.216 ms │ 646.33 KiB │   4499 │
│  CPU │  32³ │ DryEarth3 │    Energy │ 43.476 ms │  43.907 ms │  43.909 ms │  44.399 ms │ 816.50 KiB │   5635 │
│  CPU │  32³ │ DryEarth3 │   Entropy │ 57.665 ms │  58.362 ms │  58.281 ms │  58.637 ms │ 816.50 KiB │   5635 │
│  CPU │ 192³ │  DryEarth │    Energy │   6.482 s │    6.482 s │    6.482 s │    6.482 s │ 646.33 KiB │   4499 │
│  CPU │ 192³ │  DryEarth │   Entropy │   5.671 s │    5.671 s │    5.671 s │    5.671 s │ 646.33 KiB │   4499 │
│  CPU │ 192³ │ DryEarth3 │    Energy │   9.755 s │    9.755 s │    9.755 s │    9.755 s │ 816.50 KiB │   5635 │
│  CPU │ 192³ │ DryEarth3 │   Entropy │  12.861 s │   12.861 s │   12.861 s │   12.861 s │ 816.50 KiB │   5635 │
│  GPU │  32³ │  DryEarth │    Energy │  6.697 ms │   6.805 ms │   6.839 ms │   7.203 ms │   2.00 MiB │  30118 │
│  GPU │  32³ │  DryEarth │   Entropy │  6.712 ms │   6.825 ms │   6.839 ms │   6.990 ms │   2.00 MiB │  30118 │
│  GPU │  32³ │ DryEarth3 │    Energy │  8.327 ms │   8.443 ms │   8.450 ms │   8.599 ms │   2.54 MiB │  37794 │
│  GPU │  32³ │ DryEarth3 │   Entropy │  8.328 ms │   8.534 ms │   8.559 ms │   8.782 ms │   2.54 MiB │  37828 │
│  GPU │ 192³ │  DryEarth │    Energy │  6.896 ms │   7.073 ms │  27.416 ms │ 100.733 ms │   2.00 MiB │  29947 │
│  GPU │ 192³ │  DryEarth │   Entropy │  7.027 ms │   7.159 ms │  22.579 ms │  85.657 ms │   2.00 MiB │  29947 │
│  GPU │ 192³ │ DryEarth3 │    Energy │  8.627 ms │  37.640 ms │  66.270 ms │ 138.242 ms │   2.53 MiB │  37556 │
│  GPU │ 192³ │ DryEarth3 │   Entropy │ 10.052 ms │ 371.810 ms │ 300.087 ms │ 372.136 ms │   2.56 MiB │  39092 │
└──────┴──────┴───────────┴───────────┴───────────┴────────────┴────────────┴────────────┴────────────┴────────┘
Static atmosphere speedups                                                                                                                                                                                                                                  
┌──────┬───────────┬───────────┬──────────┐
│ Size │     Gases │ ThermoVar │  speedup │
├──────┼───────────┼───────────┼──────────┤
│  32³ │  DryEarth │    Energy │   4.547x │
│  32³ │  DryEarth │   Entropy │   3.901x │
│  32³ │ DryEarth3 │    Energy │   5.200x │
│  32³ │ DryEarth3 │   Entropy │   6.839x │
│ 192³ │  DryEarth │    Energy │ 916.433x │
│ 192³ │  DryEarth │   Entropy │ 792.212x │
│ 192³ │ DryEarth3 │    Energy │ 259.160x │
│ 192³ │ DryEarth3 │   Entropy │  34.591x │
└──────┴───────────┴───────────┴──────────┘
```

```
CFL benchmarks                                                                                                                                                                                                                                              
┌──────┬──────┬───────────┬───────────┬────────────┬────────────┬────────────┬────────────┬───────────┬────────┐
│ Arch │ Size │     Gases │ ThermoVar │        min │     median │       mean │        max │    memory │ allocs │
├──────┼──────┼───────────┼───────────┼────────────┼────────────┼────────────┼────────────┼───────────┼────────┤
│  CPU │  32³ │  DryEarth │    Energy │ 169.806 μs │ 176.118 μs │ 207.224 μs │ 394.418 μs │ 10.56 KiB │     89 │
│  CPU │  32³ │  DryEarth │   Entropy │ 169.068 μs │ 171.494 μs │ 198.051 μs │ 348.750 μs │ 10.56 KiB │     89 │
│  CPU │  32³ │ DryEarth3 │    Energy │ 169.157 μs │ 171.080 μs │ 198.867 μs │ 354.177 μs │ 10.56 KiB │     89 │
│  CPU │  32³ │ DryEarth3 │   Entropy │ 170.462 μs │ 172.612 μs │ 199.313 μs │ 348.443 μs │ 10.56 KiB │     89 │
│  CPU │ 128³ │  DryEarth │    Energy │  16.567 ms │  16.642 ms │  16.664 ms │  16.846 ms │ 10.56 KiB │     89 │
│  CPU │ 128³ │  DryEarth │   Entropy │  16.489 ms │  16.616 ms │  16.637 ms │  16.794 ms │ 10.56 KiB │     89 │
│  CPU │ 128³ │ DryEarth3 │    Energy │  16.506 ms │  16.605 ms │  16.612 ms │  16.694 ms │ 10.56 KiB │     89 │
│  CPU │ 128³ │ DryEarth3 │   Entropy │  16.556 ms │  16.623 ms │  16.637 ms │  16.794 ms │ 10.56 KiB │     89 │
│  GPU │  32³ │  DryEarth │    Energy │ 123.891 μs │ 134.377 μs │   5.114 ms │  49.858 ms │ 26.56 KiB │    390 │
│  GPU │  32³ │  DryEarth │   Entropy │ 124.897 μs │ 137.464 μs │   6.563 ms │  64.301 ms │ 26.56 KiB │    390 │
│  GPU │  32³ │ DryEarth3 │    Energy │ 130.946 μs │ 137.464 μs │   7.124 ms │  69.907 ms │ 26.56 KiB │    390 │
│  GPU │  32³ │ DryEarth3 │   Entropy │ 125.386 μs │ 129.054 μs │   6.917 ms │  67.879 ms │ 26.56 KiB │    390 │
│  GPU │ 128³ │  DryEarth │    Energy │ 470.065 μs │ 484.637 μs │   3.217 ms │  27.746 ms │ 26.56 KiB │    390 │
│  GPU │ 128³ │  DryEarth │   Entropy │ 464.070 μs │ 481.177 μs │   2.876 ms │  24.363 ms │ 26.56 KiB │    390 │
│  GPU │ 128³ │ DryEarth3 │    Energy │ 467.278 μs │ 486.125 μs │   2.531 ms │  20.844 ms │ 26.56 KiB │    390 │
│  GPU │ 128³ │ DryEarth3 │   Entropy │ 471.006 μs │ 499.892 μs │ 644.488 μs │   1.801 ms │ 26.56 KiB │    390 │
└──────┴──────┴───────────┴───────────┴────────────┴────────────┴────────────┴────────────┴───────────┴────────┘
```

```
Acoustic CFL benchmarks                                                                                                                                                                                                                                     
┌──────┬──────┬───────────┬───────────┬────────────┬────────────┬────────────┬────────────┬───────────┬────────┐
│ Arch │ Size │     Gases │ ThermoVar │        min │     median │       mean │        max │    memory │ allocs │
├──────┼──────┼───────────┼───────────┼────────────┼────────────┼────────────┼────────────┼───────────┼────────┤
│  CPU │  32³ │  DryEarth │    Energy │ 296.374 μs │ 304.700 μs │ 324.110 μs │ 436.374 μs │ 10.30 KiB │     87 │
│  CPU │  32³ │  DryEarth │   Entropy │ 258.295 μs │ 261.493 μs │ 283.030 μs │ 424.559 μs │ 10.30 KiB │     87 │
│  CPU │  32³ │ DryEarth3 │    Energy │ 639.663 μs │ 649.642 μs │ 678.043 μs │ 808.568 μs │ 12.52 KiB │     89 │
│  CPU │  32³ │ DryEarth3 │   Entropy │ 801.556 μs │ 807.471 μs │ 825.677 μs │ 925.027 μs │ 12.52 KiB │     89 │
│  CPU │ 128³ │  DryEarth │    Energy │  22.412 ms │  22.555 ms │  22.553 ms │  22.662 ms │ 10.30 KiB │     87 │
│  CPU │ 128³ │  DryEarth │   Entropy │  17.258 ms │  17.368 ms │  17.410 ms │  17.804 ms │ 10.30 KiB │     87 │
│  CPU │ 128³ │ DryEarth3 │    Energy │  45.287 ms │  45.626 ms │  45.847 ms │  47.513 ms │ 12.52 KiB │     89 │
│  CPU │ 128³ │ DryEarth3 │   Entropy │  50.209 ms │  50.294 ms │  50.442 ms │  51.289 ms │ 12.52 KiB │     89 │
│  GPU │  32³ │  DryEarth │    Energy │  66.410 μs │  86.664 μs │ 999.946 μs │   4.590 ms │ 23.25 KiB │    261 │
│  GPU │  32³ │  DryEarth │   Entropy │  67.151 μs │  85.801 μs │   1.019 ms │   4.530 ms │ 23.25 KiB │    261 │
│  GPU │  32³ │ DryEarth3 │    Energy │  67.744 μs │  75.371 μs │ 445.156 μs │   3.321 ms │ 27.75 KiB │    264 │
│  GPU │  32³ │ DryEarth3 │   Entropy │ 155.127 μs │ 167.926 μs │ 577.105 μs │   4.121 ms │ 27.75 KiB │    264 │
│  GPU │ 128³ │  DryEarth │    Energy │ 317.419 μs │ 348.904 μs │ 772.161 μs │   3.128 ms │ 23.25 KiB │    261 │
│  GPU │ 128³ │  DryEarth │   Entropy │ 220.590 μs │ 234.816 μs │ 899.807 μs │   4.206 ms │ 23.25 KiB │    261 │
│  GPU │ 128³ │ DryEarth3 │    Energy │ 372.372 μs │ 392.877 μs │ 559.595 μs │   1.719 ms │ 27.75 KiB │    264 │
│  GPU │ 128³ │ DryEarth3 │   Entropy │   7.426 ms │   7.443 ms │   7.480 ms │   7.620 ms │ 27.75 KiB │    264 │
└──────┴──────┴───────────┴───────────┴────────────┴────────────┴────────────┴────────────┴───────────┴────────┘
```